### PR TITLE
Add merge conflict detection for pull requests

### DIFF
--- a/.claude/commands/submit.md
+++ b/.claude/commands/submit.md
@@ -1,0 +1,34 @@
+# Submit changes
+
+1. `mise run format && mise run lint`, then fix issues
+2. `mise run tests`, then fix issues
+3. Review changes with `git status` and `git diff`, checking for commits vs the merge-base of origin/main, as well as unstaged cahnges, and staged changes
+4. Stage and commit changes:
+
+   ```bash
+   git add . # or an appropriate set of files
+   git commit -m "$(cat <<'EOF'
+   [Your commit message here]
+
+   🤖 Generated with [Claude Code](https://claude.ai/code)
+
+   Co-Authored-By: Claude <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+
+   Avoid unnecessary lists in your commit message. Avoid adding filler to lists to make them longer.
+5. `git push -u origin HEAD`
+6. Create a PR:
+
+   ```bash
+   gh pr create --title "[PR Title]" --body "$(cat <<'EOF'
+   <message>
+
+   🤖 Generated with [Claude Code](https://claude.ai/code)
+   EOF
+   )"
+   ```
+
+   Avoid unnecessary lists in the PR description. PR descriptions do not have a minimum length, just do what's appropriate. Adding fluff and over-emphasizing minor points makes you seem less intelligent.
+7. Monitor CI with `uv run cimonitor watch --pr=<pr-number>`

--- a/.claude/commands/update.md
+++ b/.claude/commands/update.md
@@ -1,0 +1,21 @@
+1. 1. `mise run format && mise run lint`, then fix issues
+2. `mise run tests`, then fix issues
+3. Review changes with `git status` and `git diff`, checking for commits vs origin/{branch}, as well as unstaged cahnges, and staged changes
+4. Stage and commit changes:
+
+   ```bash
+   git add . # or an appropriate set of files
+   git commit -m "$(cat <<'EOF'
+   [Your commit message here]
+
+   🤖 Generated with [Claude Code](https://claude.ai/code)
+
+   Co-Authored-By: Claude <noreply@anthropic.com>
+   EOF
+   )"
+   ```
+
+   Avoid unnecessary lists in your commit message. Avoid adding filler to lists to make them longer.
+5. `git push -u origin HEAD`
+6. Edit the existing open pull request using the `gh` command
+7. Monitor CI with `uv run cimonitor watch --pr=<pr-number>`

--- a/cimonitor/fetcher.py
+++ b/cimonitor/fetcher.py
@@ -201,6 +201,30 @@ class GitHubCIFetcher:
         except requests.RequestException as e:
             raise ValueError(f"Failed to get PR {pr_number} head SHA: {e}")
 
+    def get_pr_merge_status(self, owner: str, repo: str, pr_number: int) -> dict[str, Any]:
+        """Get merge status information for a pull request.
+
+        Returns:
+            Dictionary with mergeable, mergeable_state, and other PR status info
+        """
+        url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pr_number}"
+
+        try:
+            response = requests.get(url, headers=self.headers)
+            response.raise_for_status()
+            pr_data = response.json()
+
+            return {
+                "mergeable": pr_data.get("mergeable"),
+                "mergeable_state": pr_data.get("mergeable_state"),
+                "state": pr_data.get("state"),
+                "draft": pr_data.get("draft", False),
+                "base_ref": pr_data.get("base", {}).get("ref"),
+                "head_ref": pr_data.get("head", {}).get("ref"),
+            }
+        except requests.RequestException as e:
+            raise ValueError(f"Failed to get PR {pr_number} merge status: {e}")
+
     def get_branch_head_sha(self, owner: str, repo: str, branch_name: str) -> str:
         """Get the head commit SHA for a branch."""
         url = f"https://api.github.com/repos/{owner}/{repo}/branches/{branch_name}"

--- a/tests/test_cli_refactored.py
+++ b/tests/test_cli_refactored.py
@@ -30,7 +30,7 @@ def test_status_command_no_failures(
     """Test status command with no failures."""
     # Setup mocks
     mock_fetcher_class.return_value = Mock()
-    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch")
+    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch", None)
     mock_get_ci_status.return_value = CIStatusResult([], "test branch")
 
     result = runner.invoke(cli, ["status"])
@@ -50,7 +50,7 @@ def test_status_command_with_failures(
     # Setup mocks
     mock_fetcher = Mock()
     mock_fetcher_class.return_value = mock_fetcher
-    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch")
+    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch", None)
 
     failed_runs = [{"name": "Test Job", "conclusion": "failure", "html_url": "https://example.com"}]
     mock_get_ci_status.return_value = CIStatusResult(failed_runs, "test branch")
@@ -77,7 +77,7 @@ def test_logs_command_no_failures(
     """Test logs command with no failures."""
     # Setup mocks
     mock_fetcher_class.return_value = Mock()
-    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch")
+    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch", None)
     mock_get_job_logs.return_value = {
         "type": "filtered_logs",
         "target_description": "test branch",
@@ -100,7 +100,7 @@ def test_logs_command_with_specific_job(
     """Test logs command with specific job ID."""
     # Setup mocks
     mock_fetcher_class.return_value = Mock()
-    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch")
+    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch", None)
     mock_get_job_logs.return_value = {
         "type": "specific_job",
         "job_info": {
@@ -127,7 +127,7 @@ def test_logs_command_raw(mock_get_job_logs, mock_get_target_info, mock_fetcher_
     """Test logs command with raw flag."""
     # Setup mocks
     mock_fetcher_class.return_value = Mock()
-    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch")
+    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch", None)
     mock_get_job_logs.return_value = {
         "type": "raw_logs",
         "failed_jobs": [{"job": {"name": "Test Job", "id": 123}, "logs": "raw log content"}],
@@ -149,7 +149,7 @@ def test_logs_command_filtered(mock_get_job_logs, mock_get_target_info, mock_fet
     """Test logs command with filtered output."""
     # Setup mocks
     mock_fetcher_class.return_value = Mock()
-    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch")
+    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch", None)
     mock_get_job_logs.return_value = {
         "type": "filtered_logs",
         "target_description": "test branch",
@@ -196,7 +196,7 @@ def test_watch_command_success(
     """Test watch command with successful completion."""
     # Setup mocks
     mock_fetcher_class.return_value = Mock()
-    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch")
+    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch", None)
     mock_watch_ci_status.return_value = {
         "status": "success",
         "continue_watching": False,
@@ -220,7 +220,7 @@ def test_watch_command_failure(
     """Test watch command with failure."""
     # Setup mocks
     mock_fetcher_class.return_value = Mock()
-    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch")
+    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch", None)
     mock_watch_ci_status.return_value = {
         "status": "failed",
         "continue_watching": False,
@@ -243,7 +243,7 @@ def test_watch_command_initial_wait_for_no_runs(
     """Test watch command waits 10 seconds on initial 'no_runs' status."""
     # Setup mocks
     mock_fetcher_class.return_value = Mock()
-    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch")
+    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch", None)
 
     # First call returns no_runs, second call (after wait) returns success
     mock_watch_ci_status.side_effect = [
@@ -279,7 +279,7 @@ def test_watch_command_no_runs_after_wait(
     """Test watch command shows proper message when no runs found after initial wait."""
     # Setup mocks
     mock_fetcher_class.return_value = Mock()
-    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch")
+    mock_get_target_info.return_value = ("owner", "repo", "abc123", "test branch", None)
 
     # Both calls return no_runs (persists after wait)
     mock_watch_ci_status.return_value = {

--- a/tests/test_repo_functionality.py
+++ b/tests/test_repo_functionality.py
@@ -78,7 +78,7 @@ class TestGetTargetInfoWithRepo:
         mock_fetcher = Mock()
         mock_fetcher.get_pr_head_sha.return_value = "abc123"
 
-        owner, repo_name, commit_sha, target_description = get_target_info(
+        owner, repo_name, commit_sha, target_description, pr_number = get_target_info(
             mock_fetcher, "test/repo", None, None, "1", False
         )
 
@@ -86,6 +86,7 @@ class TestGetTargetInfoWithRepo:
         assert repo_name == "repo"
         assert commit_sha == "abc123"
         assert target_description == "PR #1 in test/repo"
+        assert pr_number == 1
         mock_fetcher.get_pr_head_sha.assert_called_once_with("test", "repo", 1)
 
     def test_get_target_info_with_repo_and_branch(self):
@@ -93,7 +94,7 @@ class TestGetTargetInfoWithRepo:
         mock_fetcher = Mock()
         mock_fetcher.get_branch_head_sha.return_value = "def456"
 
-        owner, repo_name, commit_sha, target_description = get_target_info(
+        owner, repo_name, commit_sha, target_description, pr_number = get_target_info(
             mock_fetcher, "test/repo", "main", None, None, False
         )
 
@@ -101,6 +102,7 @@ class TestGetTargetInfoWithRepo:
         assert repo_name == "repo"
         assert commit_sha == "def456"
         assert target_description == "branch main in test/repo"
+        assert pr_number is None
         mock_fetcher.get_branch_head_sha.assert_called_once_with("test", "repo", "main")
 
     def test_get_target_info_repo_overrides_pr_url(self):
@@ -108,7 +110,7 @@ class TestGetTargetInfoWithRepo:
         mock_fetcher = Mock()
         mock_fetcher.get_pr_head_sha.return_value = "abc123"
 
-        owner, repo_name, commit_sha, target_description = get_target_info(
+        owner, repo_name, commit_sha, target_description, pr_number = get_target_info(
             mock_fetcher,
             "override/repo",
             None,
@@ -121,6 +123,7 @@ class TestGetTargetInfoWithRepo:
         assert repo_name == "repo"
         assert commit_sha == "abc123"
         assert target_description == "PR #1 in override/repo"
+        assert pr_number == 1
         # Should call with the override repo, not the original from URL
         mock_fetcher.get_pr_head_sha.assert_called_once_with("override", "repo", 1)
 
@@ -129,7 +132,7 @@ class TestGetTargetInfoWithRepo:
         mock_fetcher = Mock()
         mock_fetcher.get_pr_head_sha.return_value = "abc123"
 
-        owner, repo_name, commit_sha, target_description = get_target_info(
+        owner, repo_name, commit_sha, target_description, pr_number = get_target_info(
             mock_fetcher, None, None, None, "https://github.com/original/repo/pull/1", False
         )
 
@@ -137,6 +140,7 @@ class TestGetTargetInfoWithRepo:
         assert repo_name == "repo"
         assert commit_sha == "abc123"
         assert target_description == "PR #1 in original/repo"
+        assert pr_number == 1
         mock_fetcher.get_pr_head_sha.assert_called_once_with("original", "repo", 1)
 
     def test_get_target_info_fallback_to_current_repo(self):
@@ -145,7 +149,7 @@ class TestGetTargetInfoWithRepo:
         mock_fetcher.get_repo_info.return_value = ("current", "repo")
         mock_fetcher.get_pr_head_sha.return_value = "abc123"
 
-        owner, repo_name, commit_sha, target_description = get_target_info(
+        owner, repo_name, commit_sha, target_description, pr_number = get_target_info(
             mock_fetcher, None, None, None, "1", False
         )
 
@@ -153,5 +157,6 @@ class TestGetTargetInfoWithRepo:
         assert repo_name == "repo"
         assert commit_sha == "abc123"
         assert target_description == "PR #1"
+        assert pr_number == 1
         mock_fetcher.get_repo_info.assert_called_once()
         mock_fetcher.get_pr_head_sha.assert_called_once_with("current", "repo", 1)

--- a/uv.lock
+++ b/uv.lock
@@ -83,7 +83,7 @@ wheels = [
 
 [[package]]
 name = "cimonitor"
-version = "0.1.5"
+version = "0.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
Fixes the UX issue where cimonitor doesn't report when PRs have merge conflicts vs the main branch, which prevents workflows from running.

The implementation uses GitHub's API to check the `mergeable` and `mergeable_state` fields to detect when PRs have conflicts or other blocking conditions, and displays clear messages explaining why workflows aren't running.

🤖 Generated with [Claude Code](https://claude.ai/code)